### PR TITLE
Enable sequel-packer to work with Ruby 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.0.2 (2023-05-03)
+
+* Remove validation on Symbol.to_proc to work with Ruby 3.0.0 since the internals of 
+  proc arity has been updated.
+
 ### 1.0.1 (2021-08-02)
 
 * Update internal method call to remove "Using the last argument as

--- a/lib/sequel/packer/validation.rb
+++ b/lib/sequel/packer/validation.rb
@@ -39,6 +39,17 @@ module Sequel
                 '...}).',
             )
           end
+
+          arity = block.arity
+
+          if !field_name && arity != 2
+            raise(
+              FieldArgumentError,
+              'When passing an arbitrary block to Sequel::Packer::field, the ' +
+                'block must accept exactly two arguments: the model and the ' +
+                'partially packed hash.',
+            )
+          end
         else
           # In this part of the if, block is not defined
 

--- a/lib/sequel/packer/validation.rb
+++ b/lib/sequel/packer/validation.rb
@@ -39,26 +39,6 @@ module Sequel
                 '...}).',
             )
           end
-
-          arity = block.arity
-
-          # When using Symbol.to_proc (field(:foo, &:calculate_foo)), the block has arity -1.
-          if field_name && arity != 1 && arity != -1
-            raise(
-              FieldArgumentError,
-              "The block used to define :#{field_name} must accept exactly " +
-                'one argument.',
-            )
-          end
-
-          if !field_name && arity != 2
-            raise(
-              FieldArgumentError,
-              'When passing an arbitrary block to Sequel::Packer::field, the ' +
-                'block must accept exactly two arguments: the model and the ' +
-                'partially packed hash.',
-            )
-          end
         else
           # In this part of the if, block is not defined
 

--- a/lib/sequel/packer/version.rb
+++ b/lib/sequel/packer/version.rb
@@ -1,5 +1,5 @@
 module Sequel
   class Packer
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
   end
 end

--- a/test/sequel/packer_test.rb
+++ b/test/sequel/packer_test.rb
@@ -64,18 +64,6 @@ class Sequel::PackerTest < Minitest::Test
     assert_includes err.message, 'String'
   end
 
-  def test_block_for_field_doesnt_accept_correct_number_of_arguments
-    err = assert_packer_declaration_raises(User) do
-      field(:user) {}
-    end
-    assert_includes err.message, 'exactly one argument'
-
-    err = assert_packer_declaration_raises(User) do
-      field(:user) {|_, _|}
-    end
-    assert_includes err.message, 'exactly one argument'
-  end
-
   def test_block_only_doesnt_accept_correct_number_of_arguments
     err = assert_packer_declaration_raises(User) do
       field {|_model|}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,6 @@ require 'awesome_print'
 require 'pry'
 require 'pry-byebug'
 
-require './models'
+require_relative './models'
 
 require "minitest/autorun"


### PR DESCRIPTION
Remove validation on Symbol.to_proc to work with Ruby 3.0.0 since the internals of proc arity has been updated.

- Update validation to work for ruby 3.0
- Add back non field_name validation
- Fix tests
- Update version and Changelog
